### PR TITLE
fix: check alarm_state in aiState

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -173,6 +173,9 @@ export class ReolinkEventEmitter extends EventEmitter {
         if (typeof state === "object" && state !== null && "state" in state) {
           return (state as { state?: number }).state === 1;
         }
+        if (typeof state === "object" && state !== null && "alarm_state" in state) {
+          return (state as { alarm_state?: number }).alarm_state === 1;
+        }
         return false;
       };
       


### PR DESCRIPTION
My cameras are returning...
```
{
  channel: 0,
  dog_cat: { alarm_state: 0, support: 1 },
  face: { alarm_state: 0, support: 0 },
  people: { alarm_state: 0, support: 1 },
  vehicle: { alarm_state: 1, support: 1 }
}
```