### PR TITLE
feat: add face/package to ai detection

### DIFF
--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -179,6 +179,8 @@ describe("ReolinkEventEmitter", () => {
         person: true,
         vehicle: false,
         pet: false,
+        face: false,
+        package: false
       });
 
       singleChannelEmitter.stop();

--- a/src/events.ts
+++ b/src/events.ts
@@ -17,6 +17,8 @@ export interface AiEvent {
   person?: boolean;
   vehicle?: boolean;
   pet?: boolean;
+  face?: boolean;
+  package?: boolean;
   [key: string]: unknown;
 }
 
@@ -33,6 +35,8 @@ interface LastState {
     person?: boolean;
     vehicle?: boolean;
     pet?: boolean;
+    face?: boolean;
+    package?: boolean;
     [key: string]: unknown;
   };
 }
@@ -152,18 +156,24 @@ export class ReolinkEventEmitter extends EventEmitter {
           person?: { state?: number };
           vehicle?: { state?: number };
           pet?: { state?: number };
+          face?: { state?: number };
+          package?: { state?: number };
           [key: string]: unknown;
         };
         person?: { state?: number };
         vehicle?: { state?: number };
         pet?: { state?: number };
+        face?: { state?: number };
+        package?: { state?: number };
         [key: string]: unknown;
       }>("GetAiState", { channel });
 
       const aiData = aiState?.value ?? aiState;
-      const personState = aiData?.person;
+      const personState = aiData?.person ?? aiData?.people;
       const vehicleState = aiData?.vehicle;
-      const petState = aiData?.pet;
+      const petState = aiData?.pet ?? aiData?.dog_cat;
+      const faceState = aiData?.face;
+      const packageState = aiData?.package;
       
       // Helper to check if state is active (handles both object with state property and direct number)
       const isStateActive = (state: unknown): boolean => {
@@ -179,11 +189,15 @@ export class ReolinkEventEmitter extends EventEmitter {
       const personActive = isStateActive(personState);
       const vehicleActive = isStateActive(vehicleState);
       const petActive = isStateActive(petState);
+      const faceActive = isStateActive(faceState);
+      const packageActive = isStateActive(packageState);
 
       const currentAiState = {
         person: personActive,
         vehicle: vehicleActive,
         pet: petActive,
+        face: faceActive,
+        package: packageActive,
       };
 
       // Check if AI state changed (not on first poll)
@@ -192,7 +206,9 @@ export class ReolinkEventEmitter extends EventEmitter {
         lastAiState !== undefined &&
         (lastAiState.person !== personActive ||
           lastAiState.vehicle !== vehicleActive ||
-          lastAiState.pet !== petActive);
+          lastAiState.pet !== petActive ||
+          lastAiState.face !== faceActive ||
+          lastAiState.package !== packageActive);
 
       if (aiChanged) {
         lastState.ai = currentAiState;
@@ -202,6 +218,8 @@ export class ReolinkEventEmitter extends EventEmitter {
           person: personActive,
           vehicle: vehicleActive,
           pet: petActive,
+          face: faceActive,
+          package: packageActive,
         } as AiEvent);
       } else {
         // Initialize state on first poll


### PR DESCRIPTION
My NVR responds with:
```
{
  channel: 8,
  dog_cat: { alarm_state: 0, support: 1 },
  face: { alarm_state: 0, support: 0 },
  package: { alarm_state: 0, support: 1 },
  people: { alarm_state: 0, support: 1 },
  vehicle: { alarm_state: 0, support: 1 }
} 
```

So I had to fix up the `person` and `pet` checks for `people` and `dog_cat`.

Moreover, this code is kinda unwieldy:

```
      const aiState = await this.client.api<{
        value?: {
          person?: { state?: number };
          vehicle?: { state?: number };
          pet?: { state?: number };
          face?: { state?: number };
          package?: { state?: number };
          [key: string]: unknown;
        };
        person?: { state?: number };
        vehicle?: { state?: number };
        pet?: { state?: number };
        face?: { state?: number };
        package?: { state?: number };
        [key: string]: unknown;
      }>("GetAiState", { channel });
```

My previous PR checks for alarm_state a few lines down, but really, I think the type here should/could be tamed a bit... but I'll leave that to you :)