### PR TITLE
feat: add GetChannelstatus and GetChnTypeInfo support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@
  */
 
 import { ReolinkClient, ReolinkMode } from "./reolink.js";
-import { getAbility, getDevInfo, getEnc } from "./endpoints/system.js";
+import { getAbility, getDevInfo, getEnc, getChannelInfo, getChannelStatus } from "./endpoints/system.js";
 import {
   rtspUrl,
   rtmpUrl,
@@ -143,7 +143,7 @@ Options:
   --help                 Show this help
 
 Commands:
-  status <ability|devinfo|enc> [--channel N]
+  status <ability|devinfo|enc|channelinfo|channelstatus> [--channel N]
   stream url <rtsp|rtmp|flv> [--channel N] [--codec h264|h265] [--streamType main|sub]
   stream playback [--channel N] [--start ISO_TIMESTAMP] [--streamType main|sub]
   rec search [--channel N] [--start ISO_TIMESTAMP] [--end ISO_TIMESTAMP] [--streamType main|sub]
@@ -267,6 +267,10 @@ async function main() {
             result = await getAbility(client);
           } else if (subcmd === "devinfo") {
             result = await getDevInfo(client);
+          } else if (subcmd === "channelinfo") {
+            result = await getChannelInfo(client, channel);
+          } else if (subcmd === "channelstatus") {
+            result = await getChannelStatus(client);
           } else if (subcmd === "enc") {
             result = await getEnc(client, channel);
           } else {

--- a/src/endpoints/system.ts
+++ b/src/endpoints/system.ts
@@ -43,6 +43,40 @@ export interface EncResponse {
 }
 
 /**
+ * Response structure from GetChnTypeInfo command
+ *
+ * Contains encoding configuration for video streams including
+ * codec, bitrate, resolution, and frame rate settings.
+ */
+export interface ChnTypeInfoResponse {
+  boardInfo?: string;
+  firmVer?: string;
+  pakSuffix?: string;
+  typeInfo?: string;
+}
+
+/**
+ * Contains status of a channel
+ */
+export interface ChannelStatusInfo {
+  channel: number;
+  name: string;
+  online: number;
+  sleep: number;
+  uid: string;
+}
+
+/**
+ * Response structure from GetChannelStatus command
+ *
+ * Contains count and array of status of each camera channel
+ */
+export interface ChannelStatus {
+  count: number;
+  status: ChannelStatusInfo[];
+}
+
+/**
  * Get device capability information
  * 
  * Queries the device's GetAbility endpoint to discover which features
@@ -118,3 +152,42 @@ export async function getEnc(
   });
 }
 
+/**
+ * Get channel information (model, firmware, etc.)
+ *
+ * Retrieves basic device identification including model number,
+ * hardware version, firmware version, and device name.
+ *
+ * @param client - An authenticated ReolinkClient instance
+ * @param channel - Camera channel number (0-based, default: 0)
+ * @returns Promise resolving to device information
+ *
+ * @example
+ * ```typescript
+ * const info = await getChannelInfo(client, channel);
+ * console.log(`Model: ${info.typeInfo}, Firmware: ${info.firmVer}`);
+ * ```
+ */
+export async function getChannelInfo(client: ReolinkClient, channel = 0): Promise<ChnTypeInfoResponse> {
+  return client.api<ChnTypeInfoResponse>("GetChnTypeInfo", {
+    channel,
+  });
+}
+
+/**
+ * Get channel status
+ *
+ * Retrieves basic status information of an NVR's camera channels
+ *
+ * @param client - An authenticated ReolinkClient instance
+ * @returns Promise resolving to device information
+ *
+ * @example
+ * ```typescript
+ * const response = await getChannelStatus(client);
+ * console.log(`Channels: ${response.count}, ${JSON.stringify(response.channels)}`);
+ * ```
+ */
+export async function getChannelStatus(client: ReolinkClient): Promise<ChannelStatus> {
+  return client.api<ChannelStatus>("GetChannelstatus", {});
+}


### PR DESCRIPTION
From my RLN36:

```
 % reolink --plain --host nvr.home --pass 123456 --user admin status channelstatus | jq -r '.status[].uid |= "xxx"'  
{
  "count": 36,
  "status": [
    {
      "channel": 0,
      "name": "Porch",
      "online": 1,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 1,
      "name": "Backyard",
      "online": 1,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 2,
      "name": "Parking Pad",
      "online": 1,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 3,
      "name": "Porch Doorbell",
      "online": 1,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 4,
      "name": "Side",
      "online": 1,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 5,
      "name": "Roof",
      "online": 1,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 6,
      "name": "Front Yard",
      "online": 1,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 7,
      "name": "Other Side",
      "online": 1,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 8,
      "name": "Backyard Doorbell",
      "online": 1,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 9,
      "name": "Parking Pad North",
      "online": 1,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 10,
      "name": "Side Gate East",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 11,
      "name": "Side Gate West",
      "online": 1,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 12,
      "name": "Roof Front",
      "online": 1,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 13,
      "name": "Network Rack",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 14,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 15,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 16,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 17,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 18,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 19,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 20,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 21,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 22,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 23,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 24,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 25,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 26,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 27,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 28,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 29,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 30,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 31,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 32,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 33,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 34,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    },
    {
      "channel": 35,
      "name": "",
      "online": 0,
      "sleep": 0,
      "uid": "xxx"
    }
  ]
}
```
and
```
 % reolink --plain --host nvr.home --pass 123456 --user admin status channelinfo --channel 5                       
{
  "boardInfo": "IPC_NT1NA44MP",
  "firmVer": "v3.1.0.3734_2407022249",
  "pakSuffix": "pak",
  "typeInfo": "CX410"
}
```